### PR TITLE
Support for sites that require cookies

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,6 +1,6 @@
 History.txt
 Manifest.txt
-README.txt
+README.md
 Rakefile
 bin/bench
 bin/crawl

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-= rails_analyzer_tools
+# rails_analyzer_tools
 
 Tools for analyzing the performance of web sites.
 
@@ -12,7 +12,7 @@ Bug reports:
 
 http://rubyforge.org/tracker/?func=add&group_id=1513&atid=5921
 
-== Bench
+## Bench
 
 Bench lets you benchmark the performance of a particular page.  Simply give
 the URL, the number of requests to run and the number of threads to run in
@@ -20,12 +20,12 @@ parallel.
 
 You really, really, really don't want to run bench against a live website.
 
-  $ bench -u http://coop.robotcoop.com/ -r 50 -c 2
-  50....45....40....35....30....25....20....15....10....5....
-  Total time: 10.7073893547058
-  Average time: 0.214147787094116
+    $ bench -u http://coop.robotcoop.com/ -r 50 -c 2
+    50....45....40....35....30....25....20....15....10....5....
+    Total time: 10.7073893547058
+    Average time: 0.214147787094116
 
-== Crawler
+## Crawler
 
 Crawler lets you exercise a server by crawling it really fast.  It picks URLs
 at random from the returned page and always stays on the same host.  When you
@@ -33,29 +33,29 @@ kill it with a ^C it prints out a summary.
 
 You really, really, really don't want to run crawl against a live website.
 
-  $ crawl -u http://coop.robotcoop.com/ -c 2
-  >>> http://coop.robotcoop.com/
-  GET / HTTP/1.0
-  Host: coop.robotcoop.com
-  User-Agent: RubyCrawl
+    $ crawl -u http://coop.robotcoop.com/ -c 2
+    >>> http://coop.robotcoop.com/
+    GET / HTTP/1.0
+    Host: coop.robotcoop.com
+    User-Agent: RubyCrawl
 
-  ...
+    ...
 
-  ^C
-  Total time: 0.355171680450439
-  Requests: 3
-  Average time: 0.118390560150146
+    ^C
+    Total time: 0.355171680450439
+    Requests: 3
+    Average time: 0.118390560150146
 
-== RailsStat
+## RailsStat
 
 RailsStat displays the approximate number of requests, queries, and lines
 logged per second in 10 (or whatever) second intervals.  Simply give it the
 path to your production log for a live Rails site and you're done:
 
-  $ rails_stat /var/log/production.log
-  ~ 2.1 req/sec, 23.0 queries/sec, 32.8 lines/sec
+    $ rails_stat /var/log/production.log
+    ~ 2.1 req/sec, 23.0 queries/sec, 32.8 lines/sec
 
-== IOTail
+## IOTail
 
 IOTail tails a file like the tail system utility.  This lets you collect data
 from a live log file.

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,9 @@ Hoe.new 'rails_analyzer_tools', AnalyzerTools::VERSION do |p|
   p.rubyforge_name = 'seattlerb'
   p.author = 'Eric Hodel'
   p.email = 'drbrain@segment7.net'
-  p.summary = p.paragraphs_of('README.txt', 1).join ' '
-  p.description = p.paragraphs_of('README.txt', 2).join ' '
-  p.url = p.paragraphs_of('README.txt', 3).join ' '
+  p.summary = p.paragraphs_of('README.md', 1).join ' '
+  p.description = p.paragraphs_of('README.md', 2).join ' '
+  p.url = p.paragraphs_of('README.md', 3).join ' '
   p.changes = p.paragraphs_of('History.txt', 0..1).join("\n\n")
 
   p.extra_deps << ['SyslogLogger', '>= 1.4.0']

--- a/bin/bench
+++ b/bin/bench
@@ -16,6 +16,7 @@ end
 uri = nil
 requests = 1
 concurrency = 1
+ignore_count = 0
 cookies = nil
 
 opts = OptionParser.new do |opts|
@@ -42,6 +43,11 @@ opts = OptionParser.new do |opts|
             cookies = val
           end
 
+  opts.on("-i", "--ignore N",
+          "Number of initial fetch requests to exclude from the final stats. Useful if you know that the first request will be uncached.") do |val|
+            ignore_count = val.to_i
+          end
+
 end
 
 opts.parse!
@@ -54,6 +60,6 @@ end
 bench = Bench.new uri, requests, concurrency, cookies
 times = bench.run
 
-puts "Total time: #{times.inject(0) { |a,t| a + t }}"
-puts "Average time: #{times.inject(0) { |a,t| a + t } / times.length}"
+puts "Total time: #{times[ignore_count..-1].inject(0) { |a,t| a + t }}"
+puts "Average time: #{times[ignore_count..-1].inject(0) { |a,t| a + t } / (times.length - ignore_count)}"
 

--- a/bin/bench
+++ b/bin/bench
@@ -16,6 +16,7 @@ end
 uri = nil
 requests = 1
 concurrency = 1
+cookies = nil
 
 opts = OptionParser.new do |opts|
   opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
@@ -36,6 +37,11 @@ opts = OptionParser.new do |opts|
             concurrency = val
           end
 
+  opts.on("-C", "--cookies COOKIES",
+          "Optional string to pass in the cookies header. Should be a semi-colon separated list of key-value pairs, e.g. 'name=value; name2=value2'") do |val|
+            cookies = val
+          end
+
 end
 
 opts.parse!
@@ -45,7 +51,7 @@ if uri.nil? or requests.nil? then
   exit
 end
 
-bench = Bench.new uri, requests, concurrency
+bench = Bench.new uri, requests, concurrency, cookies
 times = bench.run
 
 puts "Total time: #{times.inject(0) { |a,t| a + t }}"

--- a/bin/crawl
+++ b/bin/crawl
@@ -15,6 +15,7 @@ end
 
 start_url = nil
 concurrency = 1
+cookies = nil
 
 opts = OptionParser.new do |opts|
   opts.banner = "Usage: #{$PROGRAM_NAME} -u URL [-c CONCURRENCY]"
@@ -32,6 +33,11 @@ opts = OptionParser.new do |opts|
     concurrency = val
   end
 
+  opts.on("-C", "--cookies COOKIES",
+          "Optional string to pass in the cookies header. Should be a semi-colon separated list of key-value pairs, e.g. 'name=value; name2=value2'") do |val|
+    cookies = val
+  end
+
 end
 
 opts.parse!
@@ -41,7 +47,7 @@ if start_url.nil? then
   exit 1
 end
 
-crawler = Crawler.new start_url, concurrency
+crawler = Crawler.new start_url, concurrency, cookies
 
 trap 'INT' do
   crawler.stop

--- a/lib/analyzer_tools/bench.rb
+++ b/lib/analyzer_tools/bench.rb
@@ -13,7 +13,7 @@ class Bench
   # Creates a new Bench instance that will +requests+ fetches of +uri+ using
   # +thread+ concurrent threads.
 
-  def initialize(uri, requests, threads = 1)
+  def initialize(uri, requests, threads = 1, cookies = nil)
     raise ArgumentError, "Thread count must be more than 0" if threads < 1
     @uri = uri
     @total_requests = requests
@@ -21,6 +21,7 @@ class Bench
     @hundredths = @total_requests > 100 ? @total_requests / 100 : 1
     @num_requests = requests
     @threads = threads
+    @cookies = cookies
   end
 
   ##
@@ -67,6 +68,7 @@ class Bench
     s.puts "GET #{@uri.request_uri} HTTP/1.0\r\n"
     s.puts "Host: #{@uri.host}\r\n"
     s.puts "User-Agent: RubyBench\r\n"
+    s.puts "Cookie: #{@cookies}\r\n" if @cookies
     s.puts "\r\n"
     s.flush
     response = s.read

--- a/lib/analyzer_tools/crawl.rb
+++ b/lib/analyzer_tools/crawl.rb
@@ -22,12 +22,13 @@ class Crawler
   # Creates a new Crawler that will start at +start_url+ and run +threads+
   # concurrent threads.
 
-  def initialize(start_url, threads = 1)
+  def initialize(start_url, threads = 1, cookies = nil)
     raise ArgumentError, "Thread count must be more than 0" if threads < 1
     @start_url = start_url
     @thread_count = threads
     @threads = ThreadGroup.new
     @times = []
+    @cookies = cookies
   end
 
   ##
@@ -66,6 +67,7 @@ class Crawler
     req << "GET #{url.request_uri} HTTP/1.0"
     req << "Host: #{url.host}"
     req << "User-Agent: RubyCrawl"
+    req << "Cookie: #{@cookies}" if @cookies
     req << ""
     req << ""
     req = req.join "\r\n"


### PR DESCRIPTION
I have added a new optional "cookies" parameter to both the "bench" and "crawl" commands, allowing you to use them with sites that require cookies to view.
I've also tweaked the README so that the Markdown renders correctly in Github
